### PR TITLE
Fix HUUUUUUUGE BUG of ReportGateway

### DIFF
--- a/src/main/java/report_use_case/gateways/reportDsGateway.java
+++ b/src/main/java/report_use_case/gateways/reportDsGateway.java
@@ -10,5 +10,5 @@ public interface reportDsGateway {
 
     void save(ReportDsRequestModel reportdsRequestModel) throws IOException;
 
-    boolean existsReportByReporterAndReview(String reporter_username, String review_id);
+    boolean existsReportByReporterAndReview(String reporter_username, String review_id) throws IOException;
 }


### PR DESCRIPTION
Bug: After sending a report, if the current user didn't close the program and re-log in, he could keep reporting the same review

Cause: FileReportHistory was initialized when ReportButton was created; When FileReportHistory was initialized, checkReport (MultiMap) was created and fixed. Then, when the user clicked report again, existsReportByReporterAndReview was using the old
unchanged checkReport, thus duplicated report couldn't be caught.

Solution: add a new MultiMap, refreshedReports, which will be refreshed everytime existsReportByReporterAndReview is used; existsReportByReporterAndReview  is now checking both checkReport and refreshedReports. 